### PR TITLE
fix: 修复 package.sh 签名分支 set -u 报未绑定变量

### DIFF
--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -70,7 +70,7 @@ if [ "$UNSIGNED" = "1" ]; then
     echo "⚠️  --unsigned：ad-hoc 签名（CI/预览通道，TCC 授权不跨版本存活）"
     codesign --force --identifier "$BUNDLE_ID" --sign - "$APP"
 else
-    echo "-- 签名（证书: $CERT_CN, identifier: $BUNDLE_ID）"
+    echo "-- 签名（证书: $CERT_CN, identifier: ${BUNDLE_ID}）"
     codesign --force \
         --identifier "$BUNDLE_ID" \
         --sign "$CERT_CN" \


### PR DESCRIPTION
## 这个 PR 做了什么

修复 `scripts/package.sh` 签名分支在 `set -u` 下报未绑定变量。

签名分支的 echo 语句里 `$BUNDLE_ID` 后紧跟全角 `）` 且无空格，bash 3.2 在 UTF-8 locale 下会把 `U+FF09` 的首字节 `0xEF` 并入标识符，变量名变成 `BUNDLE_ID\xEF`，未定义即 ABORT（exit 127）。改为 `${BUNDLE_ID}` 显式闭合变量名。

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档 / 注释
- [x] 打包 / CI / 脚本
- [ ] 重构（不改变外部行为）

## 验证

- [x] 本地 `./build.sh` && `.build/miremote --self-test` 全绿（SELF-TEST PASS）
- [x] 改了打包 / 签名脚本：`bash -n scripts/*.sh` 语法通过
- [ ] 改了运行时行为：不涉及，无实机验证

实机验证说明：无（纯脚本层修复，不涉及运行时行为）

## 补充说明

此路径此前未被 CI 覆盖：`ci.yml` 仅执行 build + self-test，`release.yml` 打包走 `--unsigned` 分支，签名分支只有本地有固定证书时才会执行，故该问题在 CI 上从未暴露。建议后续给签名分支补一次本机验证或 CI 内挂载证书的冒烟测试，防止此类回归。
